### PR TITLE
change availableExtensions() method to instance method

### DIFF
--- a/src/ReSTProcessor.js
+++ b/src/ReSTProcessor.js
@@ -7,7 +7,7 @@ export default class ReSTProcessor {
         this.config = config;
     }
 
-    static availableExtensions() {
+    availableExtensions() {
         return [
             ".rst",
             ".rest"


### PR DESCRIPTION
Thanks you for publishing such a great product!  
Today I found one problem in this module, so I want to suggest this PR.

According to [release note for textlint v11](https://textlint.github.io/blog/2018/07/22/textlint-11.html#developer-deprecate-static-availableextensions-in-plugin-processor), `static availableExtensions()` method has been deprecated.
We should use instance method instead, to support extending by options.
